### PR TITLE
Feature/chat implementation

### DIFF
--- a/src/main/java/com/example/charservice/configs/WebSocketConfiguration.java
+++ b/src/main/java/com/example/charservice/configs/WebSocketConfiguration.java
@@ -1,0 +1,22 @@
+package com.example.charservice.configs;
+
+import com.example.charservice.handlers.WebSocketChatHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.socket.config.annotation.EnableWebSocket;
+import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+
+@RequiredArgsConstructor
+@EnableWebSocket
+@Configuration
+public class WebSocketConfiguration implements WebSocketConfigurer {
+
+    final WebSocketChatHandler webSocketChatHandler; // final 멤버 변수는 생성자가 반드시 필요, RequiredArgsConstructor 롬복으로 대체 가능
+
+
+    @Override
+    public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
+        registry.addHandler(webSocketChatHandler, "/ws/chats");
+    }
+}

--- a/src/main/java/com/example/charservice/handlers/WebSocketChatHandler.java
+++ b/src/main/java/com/example/charservice/handlers/WebSocketChatHandler.java
@@ -7,22 +7,43 @@ import org.springframework.web.socket.WebSocketMessage;
 import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.handler.TextWebSocketHandler;
 
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
 @Slf4j
 @Component // 빈으로 등록해줘야함.
 public class WebSocketChatHandler extends TextWebSocketHandler {
+
+    final Map<String, WebSocketSession> webSocketMap = new ConcurrentHashMap<>(); // 서버 접속한 클라이언트 정보 추적
+
     // 웹소켓 클라이언트가 서버로 연결 시
     @Override
     public void afterConnectionEstablished(WebSocketSession session) throws Exception {
-        log.info("{} conntection", session.getId());
+        log.info("{} connection", session.getId());
+
+        this.webSocketMap.put(session.getId(), session);
     }
     // 웹소켓 클라이어트에서 메시지 왔을 때 처리
     @Override
     public void handleMessage(WebSocketSession session, WebSocketMessage<?> message) throws Exception {
-        super.handleMessage(session, message);
+        log.info("{} sent {}", session.getId(), message.getPayload());
+
+        this.webSocketMap.values().forEach(
+                webSocketSession -> {
+                    try {
+                        webSocketSession.sendMessage(message);
+                    } catch (IOException e) {
+                         throw new RuntimeException(e);
+                    }
+                }
+        );
     }
     // 서버에 접속한 웹소켓 클라이언트가 연결 종료 시
     @Override
     public void afterConnectionClosed(WebSocketSession session, CloseStatus status) throws Exception {
         log.info("{} disconnection", session.getId());
+
+        this.webSocketMap.remove(session.getId());
     }
 }

--- a/src/main/java/com/example/charservice/handlers/WebSocketChatHandler.java
+++ b/src/main/java/com/example/charservice/handlers/WebSocketChatHandler.java
@@ -1,0 +1,28 @@
+package com.example.charservice.handlers;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.WebSocketMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+
+@Slf4j
+@Component // 빈으로 등록해줘야함.
+public class WebSocketChatHandler extends TextWebSocketHandler {
+    // 웹소켓 클라이언트가 서버로 연결 시
+    @Override
+    public void afterConnectionEstablished(WebSocketSession session) throws Exception {
+        log.info("{} conntection", session.getId());
+    }
+    // 웹소켓 클라이어트에서 메시지 왔을 때 처리
+    @Override
+    public void handleMessage(WebSocketSession session, WebSocketMessage<?> message) throws Exception {
+        super.handleMessage(session, message);
+    }
+    // 서버에 접속한 웹소켓 클라이언트가 연결 종료 시
+    @Override
+    public void afterConnectionClosed(WebSocketSession session, CloseStatus status) throws Exception {
+        log.info("{} disconnection", session.getId());
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,8 @@
 spring:
   application:
     name : char-service
+logging:
+  file:
+    name: logs/application.log  # 로그 파일 경로 지정
+  level:
+    root: info  # 로그 레벨 설정 (debug, info, warn, error)

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -26,40 +26,44 @@
       </form>
     </div>
   </div>
+<!--  <div class="row">-->
+<!--    <div class="col-md-12">-->
+<!--      <form class="form-inline">-->
+<!--        <div class="form-group">-->
+<!--          <label for="create">Chatroom</label>-->
+<!--          <input type="text" id="chatroom-id" class="form-control" disabled="disabled" placeholder="chatroom id">-->
+<!--          <input type="text" id="chatroom-title" class="form-control" placeholder="chatroom title">-->
+<!--        </div>-->
+<!--        <button id="create" class="btn btn-default" disabled="disabled" type="button">Create</button>-->
+<!--        <button id="leave" class="btn btn-default" disabled="disabled" type="button">Leave</button>-->
+<!--      </form>-->
+<!--    </div>-->
+<!--  </div>-->
+<!--  <div class="row">-->
+<!--    <div class="col-md-12">-->
+<!--      <table id="chatrooms" class="table table-striped">-->
+<!--        <thead>-->
+<!--        <tr>-->
+<!--          <th>Chatrooms</th>-->
+<!--        </tr>-->
+<!--        </thead>-->
+<!--        <tbody id="chatroom-list">-->
+<!--        </tbody>-->
+<!--      </table>-->
+<!--    </div>-->
+<!--  </div>-->
   <div class="row">
     <div class="col-md-12">
       <form class="form-inline">
         <div class="form-group">
-          <label for="create">Chatroom</label>
-          <input type="text" id="chatroom-id" class="form-control" disabled="disabled" placeholder="chatroom id">
-          <input type="text" id="chatroom-title" class="form-control" placeholder="chatroom title">
+          <label for="send">Username</label>
+          <input type="text" id="username" class="form-control" placeholder="username to send">
         </div>
-        <button id="create" class="btn btn-default" disabled="disabled" type="button">Create</button>
-        <button id="leave" class="btn btn-default" disabled="disabled" type="button">Leave</button>
-      </form>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-md-12">
-      <table id="chatrooms" class="table table-striped">
-        <thead>
-        <tr>
-          <th>Chatrooms</th>
-        </tr>
-        </thead>
-        <tbody id="chatroom-list">
-        </tbody>
-      </table>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-md-12">
-      <form class="form-inline">
         <div class="form-group">
           <label for="send">Message</label>
           <input type="text" id="message" class="form-control" placeholder="message to send">
         </div>
-        <button id="send" class="btn btn-default" disabled="disabled" type="button">Send</button>
+        <button id="send" class="btn btn-default" type="button">Send</button>
       </form>
     </div>
   </div>

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -7,7 +7,7 @@
   <link href="/main.css" rel="stylesheet">
   <script src="https://code.jquery.com/jquery-3.1.1.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/@stomp/stompjs@7.0.0/bundles/stomp.umd.min.js"></script>
-  <script src="/stomp.js"></script>
+  <script src="/websocket.js"></script>
 </head>
 <body>
 <noscript><h2 style="color: #ff0000">Seems your browser doesn't support Javascript! Websocket relies on Javascript being


### PR DESCRIPTION
트러블슈팅
- send버튼이 클릭이 안되는 상황 발생 : html에서 default로 disabled 된 부분을 삭제하여 해결
- 메시지가 보이지 않는 상황 발생 : stomp.js파일로 서버가 통신되는 것을 확인, html에서 script src를 websocket.js파일로 변경

새롭게 알게된 것
- Spring은 DispatcherServlet을 제공하기 때문에 Handler를 직접 구현할 필요x
- 웹소켓은 지속적인 데이터 송수신이 필요하여 직접 핸들러 작성해야한다. 따라서 엔드포인트에 getMapping, PostMapping처럼 Configure에 "ws/chats"경로를 추가하였다.
